### PR TITLE
fix: comply with original HTTP API by disabling AbortControlle by defeault

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ $ meteor npm run lint:code     # run linter in check mode
 $ meteor npm run lint:code-fix # run linter and autofix issues
 $ meteor npm run test          # run test once
 $ meteor npm run test:watch    # run tests in watch mode
-$ meteor npm run test:coverage # run tests once but with coverage report
 ```
 
 
 ## Changelog
 
+- **2.3.0**
+  - AbortController is not used by default to comply with original API.
+    If a value greater than -1 is given as timeout then AbortController will
+    be called after that timeout.
 - **2.2.0**
   - Add `HTTP.debug` to API to allow debugging of unsensitive internals
 - **2.1.0**

--- a/httpcall_server.js
+++ b/httpcall_server.js
@@ -181,7 +181,11 @@ function _call (method, url, options, callback) {
       }
     })
     .catch(err => callback(err))
-    .finally(() => clearTimeout(timeoutId))
+    .finally(() => {
+      if (typeof timeoutId !== 'undefined') {
+        clearTimeout(timeoutId)
+      }
+    })
 }
 
 HTTP.call = Meteor.wrapAsync(_call)

--- a/httpcall_server.js
+++ b/httpcall_server.js
@@ -89,7 +89,7 @@ function _call (method, url, options, callback) {
 
   const caching = options.cache || 'cache'
   const corsMode = options.mode || 'cors'
-  const timeout = options.timeout || 90000
+  const timeout = options.timeout || -1
   const useAbort = timeout > -1
   const controller = useAbort
     ? new AbortControllerImpl()


### PR DESCRIPTION
Disabled AbortController by default by setting the defualt timeout value to -1 and only include AbortController if the timeout is greater than -1

